### PR TITLE
resume.typ: Ensure that period_worked is language agnostic regarding present end-date

### DIFF
--- a/src/resume.typ
+++ b/src/resume.typ
@@ -1,45 +1,19 @@
 #let resume(
-  paper: "a4",
-  top-margin: 0.4in,
-  bottom-margin: 0.2in,
-  left-margin: 0.3in,
-  right-margin: 0.3in,
-  font: "New Computer Modern",
-  font-size: 11pt,
-  personal-info-font-size: 10.5pt,
-  author-name: "",
-  author-position: center,
-  personal-info-position: center,
-  phone: "",
-  location: "",
-  email: "",
-  website: "",
-  linkedin-user-id: "",
-  github-username: "",
-  body
+  paper: "a4", top-margin: 0.4in, bottom-margin: 0.2in, left-margin: 0.3in, right-margin: 0.3in, font: "New Computer Modern", font-size: 11pt, personal-info-font-size: 10.5pt, author-name: "", author-position: center, personal-info-position: center, phone: "", location: "", email: "", website: "", linkedin-user-id: "", github-username: "", body,
 ) = {
   set document(
-    title: "Résumé | " + author-name,
-    author: author-name,
-    keywords: "cv",
-    date: none
+    title: "Résumé | " + author-name, author: author-name, keywords: "cv", date: none,
   )
 
   set page(
-    paper: "a4",
-    margin: (
-      top: top-margin, bottom: bottom-margin,
-      left: left-margin, right: right-margin
+    paper: "a4", margin: (
+      top: top-margin, bottom: bottom-margin, left: left-margin, right: right-margin,
     ),
   )
 
-  set text(
-    font: font, size: font-size, lang: "en", ligatures: false
-  )
+  set text(font: font, size: font-size, lang: "en", ligatures: false)
 
-  show heading.where(
-    level: 1
-  ): it => block(width: 100%)[
+  show heading.where(level: 1): it => block(width: 100%)[
     #set text(font-size + 2pt, weight: "regular")
     #smallcaps(it.body)
     #v(-1em)
@@ -58,31 +32,34 @@
   }
 
   align(author-position, [
-    #upper(text(font-size+16pt, weight: "extrabold")[#author-name])
+    #upper(text(font-size + 16pt, weight: "extrabold")[#author-name])
     #v(-2em)
   ])
 
-  align(personal-info-position, text(personal-info-font-size)[    
-    #{
-      let sepSpace = 0.2em
-      let items = (
-        contact_item(phone),
-        contact_item(location),
-        contact_item(email, link-type: "mailto:"),
-        contact_item(website, link-type: "https://"),
-        contact_item(linkedin-user-id, link-type: "https://linkedin.com/in/", prefix: "linkedin.com/in/"),
-        contact_item(github-username, link-type: "https://github.com/", prefix: "github.com/"),
-      )
-      items.filter(x => x != none).join([
-        #show "|": sep => {
-          h(sepSpace)
-          [|]
-          h(sepSpace)
-        }
-        |
-      ])
-    }
-  ])
+  align(
+    personal-info-position, text(
+      personal-info-font-size,
+    )[
+      #{
+        let sepSpace = 0.2em
+        let items = (
+          contact_item(phone), contact_item(location), contact_item(email, link-type: "mailto:"), contact_item(website, link-type: "https://"), contact_item(
+            linkedin-user-id, link-type: "https://linkedin.com/in/", prefix: "linkedin.com/in/",
+          ), contact_item(
+            github-username, link-type: "https://github.com/", prefix: "github.com/",
+          ),
+        )
+        items.filter(x => x != none).join([
+          #show "|": sep => {
+            h(sepSpace)
+            [|]
+            h(sepSpace)
+          }
+          |
+        ])
+      }
+    ],
+  )
 
   body
 }
@@ -91,22 +68,14 @@
 // Custom functions
 
 #let generic_1x2(r1c1, r1c2) = {
-  grid(
-    columns: (1fr, 1fr),
-    align(left)[#r1c1],
-    align(right)[#r1c2]
-  )
+  grid(columns: (1fr, 1fr), align(left)[#r1c1], align(right)[#r1c2])
 }
 
 #let generic_2x2(cols, r1c1, r1c2, r2c1, r2c2) = {
   // sanity checks
   assert.eq(type(cols), array)
 
-  grid(
-    columns: cols,
-    align(left)[#r1c1 \ #r2c1],
-    align(right)[#r1c2 \ #r2c2]
-  )
+  grid(columns: cols, align(left)[#r1c1 \ #r2c1], align(right)[#r1c2 \ #r2c2])
 }
 
 #let custom-title(title, spacing-between: -0.5em, body) = {
@@ -119,11 +88,7 @@
 #let skills(body) = {
   if body != [] {
     set par(leading: 0.6em)
-    set list(
-      body-indent: 0.1em,
-      indent: 0em,
-      marker: []
-    )
+    set list(body-indent: 0.1em, indent: 0em, marker: [])
     body
   }
 }
@@ -134,20 +99,13 @@
   assert.eq(type(start-date), datetime)
   assert(type(end-date) == datetime or type(end-date) == str)
 
-  if type(end-date) == str and end-date == "Present" {
-    end-date = datetime.today()
-  }
-
   return [
-      #start-date.display("[month repr:short] [year]") -- 
-      #if (
-        (end-date.month() == datetime.today().month()) and 
-        (end-date.year() == datetime.today().year())
-      ) [
-        Present
-      ] else [
-        #end-date.display("[month repr:short] [year]")
-      ]
+    #start-date.display("[month repr:short] [year]") --
+    #if (type(end-date) == str) [
+      #end-date
+    ] else [
+      #end-date.display("[month repr:short] [year]")
+    ]
   ]
 }
 
@@ -158,9 +116,7 @@
   assert(type(end-date) == datetime or type(end-date) == str)
 
   generic_2x2(
-    (1fr, 1fr),
-    [*#title*], [*#period_worked(start-date, end-date)*], 
-    [#company], emph(location)
+    (1fr, 1fr), [*#title*], [*#period_worked(start-date, end-date)*], [#company], emph(location),
   )
   v(-0.2em)
   if body != [] {
@@ -174,7 +130,7 @@
 // Pretty self-explanatory.
 #let project-heading(name, stack: "", project-url: "", body) = {
   if project-url.len() != 0 { link(project-url)[*#name*] } else {
-    [*#name*] 
+    [*#name*]
   }
   if stack != "" {
     [
@@ -198,9 +154,7 @@
   assert(type(end-date) == datetime or type(end-date) == str)
 
   generic_2x2(
-    (70%, 30%),
-    [*#institution*], [*#location*], 
-    [#degree, #major], period_worked(start-date, end-date)
+    (70%, 30%), [*#institution*], [*#location*], [#degree, #major], period_worked(start-date, end-date),
   )
   v(-0.2em)
   if body != [] {


### PR DESCRIPTION
### Summary

This PR refines the `period_worked` function in `resume.typ` to ensure consistent behavior regardless of localization or language settings — particularly when handling the **Present** end-date case.

---

### Details

- **Problem**: Previously, when `end-date` was a string other than `"Present"`, the logic was hardcoded to reject it. This introduced localization assumptions and will misbehave if the user’s locale differs.
- **Fix**: Updated the conditional to treat `"Present"` purely based on its value and type, decoupling it from locale-sensitive assumptions.

---