### PR TITLE
Add `present-label` parameter to `period_worked` for configurable "Present" handling

### DIFF
--- a/src/resume.typ
+++ b/src/resume.typ
@@ -148,10 +148,10 @@
 }
 
 // Pretty self-explanatory.
-#let work-heading(title, company, location, start-date, end-date, body, present-label: "Present") = {
+#let work-heading(title, company, location, start-date, end-date, present-label: "Present", body) = {
   // sanity checks
   assert.eq(type(start-date), datetime)
-  assert(type(end-date) == datetime or type(end-date) == str)
+  assert.eq(type(end-date), datetime)
 
   generic_2x2(
     (1fr, 1fr),
@@ -188,10 +188,10 @@
 }
 
 // Pretty self-explanatory.
-#let education-heading(institution, location, degree, major, start-date, end-date, body, present-label: "Present") = {
+#let education-heading(institution, location, degree, major, start-date, end-date, present-label: "Present", body) = {
   // sanity checks
   assert.eq(type(start-date), datetime)
-  assert(type(end-date) == datetime or type(end-date) == str)
+  assert.eq(type(end-date), datetime)
 
   generic_2x2(
     (70%, 30%),

--- a/src/resume.typ
+++ b/src/resume.typ
@@ -148,14 +148,14 @@
 }
 
 // Pretty self-explanatory.
-#let work-heading(title, company, location, start-date, end-date, body) = {
+#let work-heading(title, company, location, start-date, end-date, body, present-label: "Present") = {
   // sanity checks
   assert.eq(type(start-date), datetime)
   assert(type(end-date) == datetime or type(end-date) == str)
 
   generic_2x2(
     (1fr, 1fr),
-    [*#title*], [*#period_worked(start-date, end-date)*], 
+    [*#title*], [*#period_worked(start-date, end-date, present-label: present-label)*], 
     [#company], emph(location)
   )
   v(-0.2em)
@@ -188,7 +188,7 @@
 }
 
 // Pretty self-explanatory.
-#let education-heading(institution, location, degree, major, start-date, end-date, body) = {
+#let education-heading(institution, location, degree, major, start-date, end-date, body, present-label: "Present") = {
   // sanity checks
   assert.eq(type(start-date), datetime)
   assert(type(end-date) == datetime or type(end-date) == str)
@@ -196,7 +196,7 @@
   generic_2x2(
     (70%, 30%),
     [*#institution*], [*#location*], 
-    [#degree, #major], period_worked(start-date, end-date)
+    [#degree, #major], period_worked(start-date, end-date, present-label: present-label)
   )
   v(-0.2em)
   if body != [] {

--- a/src/resume.typ
+++ b/src/resume.typ
@@ -137,7 +137,8 @@
   return [
       #start-date.display("[month repr:short] [year]") -- 
       #if (
-        end-date == datetime.today()
+        (end-date.month() == datetime.today().month()) and 
+        (end-date.year() == datetime.today().year())
       ) [
         #present-label
       ] else [

--- a/src/resume.typ
+++ b/src/resume.typ
@@ -134,17 +134,12 @@
   assert.eq(type(start-date), datetime)
   assert(type(end-date) == datetime or type(end-date) == str)
 
-  if type(end-date) == str and end-date == "Present" {
-    end-date = datetime.today()
-  }
-
   return [
       #start-date.display("[month repr:short] [year]") -- 
       #if (
-        (end-date.month() == datetime.today().month()) and 
-        (end-date.year() == datetime.today().year())
+        type(end-date) == str
       ) [
-        Present
+        #end-date
       ] else [
         #end-date.display("[month repr:short] [year]")
       ]

--- a/src/resume.typ
+++ b/src/resume.typ
@@ -129,17 +129,17 @@
 }
 
 // Converts datetime format into readable period.
-#let period_worked(start-date, end-date) = {
+#let period_worked(start-date, end-date, present-label: "Present") = {
   // sanity checks
   assert.eq(type(start-date), datetime)
-  assert(type(end-date) == datetime or type(end-date) == str)
+  assert.eq(type(end-date), datetime)
 
   return [
       #start-date.display("[month repr:short] [year]") -- 
       #if (
-        type(end-date) == str
+        end-date == datetime.today()
       ) [
-        #end-date
+        #present-label
       ] else [
         #end-date.display("[month repr:short] [year]")
       ]


### PR DESCRIPTION
### Summary

This PR updates the `period_worked` function in `resume.typ` to align with maintainer feedback and provide a cleaner, more flexible way to handle ongoing periods.

---

### Changes

- Added an optional `present-label` parameter (default: `"Present"`).
- Required `end-date` to always be a `datetime`.
- Replaced implicit `"Present"` string detection with an explicit check:
  - If `end-date == datetime.today()`, display the `present-label`.
  - Otherwise, display the formatted `end-date`.